### PR TITLE
Feature/202109/zoned date time

### DIFF
--- a/src/main/java/model/weather/WeatherValue.java
+++ b/src/main/java/model/weather/WeatherValue.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class WeatherValue {
     public String city;
-    public String currentTime;
+    public String timestamp;
     public int measuringTime = 0;
     public String targetWeather;
     public String currentWeather;
@@ -24,7 +24,7 @@ public class WeatherValue {
     public void printData() {
         System.out.println("\n=== Weatherクラスのデータ 開始 ===");
         System.out.println("都市：" + this.city);
-        System.out.println("現在時刻：" + this.currentTime);
+        System.out.println("現在時刻：" + this.timestamp);
         System.out.println("計測時間：" + this.measuringTime);
         System.out.println("計測対象の天気：" + this.targetWeather);
         System.out.println("現在の天気：" + this.currentWeather);

--- a/src/main/java/run/ElasticCreateIndex.java
+++ b/src/main/java/run/ElasticCreateIndex.java
@@ -27,6 +27,9 @@ public class ElasticCreateIndex {
 
         // index が作成されたか確認
         System.out.println("response id: " + createIndexResponse.index());
+
+        // クライアントを閉じる
+        client.close();
     }
 
 }

--- a/src/main/java/run/ElasticCreateIndex.java
+++ b/src/main/java/run/ElasticCreateIndex.java
@@ -18,7 +18,7 @@ public class ElasticCreateIndex {
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
 
         // Elasticsearch に新しい index を作成
-        CreateIndexRequest request = new CreateIndexRequest("weatherindex");
+        CreateIndexRequest request = new CreateIndexRequest("weatherjstindex");
         request.settings(Settings.builder()
                 .put("index.number_of_shards", 1)
                 .put("index.number_of_replicas", 2));

--- a/src/main/java/run/TimerTaskCall.java
+++ b/src/main/java/run/TimerTaskCall.java
@@ -74,7 +74,7 @@ public class TimerTaskCall extends TimerTask {
 
             id += 1;
 
-            weatherValue.currentTime = currentTime;
+            weatherValue.timestamp = currentTime;
             weatherValue.currentWeather = currentWeather;
             weatherValue.measuringTime += timeInterval;
 

--- a/src/main/java/run/TimerTaskCall.java
+++ b/src/main/java/run/TimerTaskCall.java
@@ -1,6 +1,6 @@
 package run;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +29,8 @@ import model.weather.WeatherValue;
 
 public class TimerTaskCall extends TimerTask {
 
-    DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+    // 日付/時間をオフセット付きで書式設定または解析するISO日付/時間フォーマッタ(「2011-12-03T10:15:30+01:00」など)
+    DateTimeFormatter dateTimeFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
     WebAPI openWeatherAPI = new WebAPI("https://api.openweathermap.org/data/2.5/weather",
             "?q=tokyo&units=metric",
@@ -68,7 +69,7 @@ public class TimerTaskCall extends TimerTask {
             System.out.println("\n=== weatherDescription ===\n" + currentWeather);
 
             // 現在日時情報を指定フォーマットの文字列で取得
-            String currentTime = LocalDateTime.now().format(dateTimeFormat);
+            String currentTime = ZonedDateTime.now().format(dateTimeFormat);
             System.out.println("\n=== 現在時刻 ===\n" + currentTime + "\n");
 
             id += 1;

--- a/src/main/java/run/TimerTaskCall.java
+++ b/src/main/java/run/TimerTaskCall.java
@@ -55,7 +55,7 @@ public class TimerTaskCall extends TimerTask {
     // Elasticsearch に接続
     RestHighLevelClient client = new RestHighLevelClient(
             RestClient.builder(new HttpHost("localhost", 9200, "http")));
-    IndexRequest indexRequest = new IndexRequest("weatherindex");
+    IndexRequest indexRequest = new IndexRequest("weatherjstindex");
 
     @Override
     public void run() {


### PR DESCRIPTION
### Elasticsearch にデータを入れる際に時刻が9時間ずれる問題を解消

- `LocalDateTime` => `ZonedDateTime`
- format を ISO_OFFSET_DATE_TIME へ変更